### PR TITLE
clean up ?page= remnants

### DIFF
--- a/ghutils.js
+++ b/ghutils.js
@@ -45,7 +45,7 @@ function issuesList (type) {
       options  = {}
     }
 
-    var url = 'https://api.github.com/repos/' + org + '/' + repo + '/' + type + '?page=' + page + optqs
+    var url = 'https://api.github.com/repos/' + org + '/' + repo + '/' + type
     lister(auth, url, options, callback)
   }
 }


### PR DESCRIPTION
I guess this is left from previous refactor into the `lister` function which now appends that to the base url.
