### PR TITLE
export the api root url

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Given a paginated url resource, recursively fetch all available pages of data an
 
 Creates an issues or pull requests fetching function where `type` is either `'issues'` or `'pulls'`. The function returned has the signature: `function list (auth, org, repo, options, callback)`.
 
+### apiRoot
+
+The api root url `'https://api.github.com'`.
+
 ## License & Copyright
 
 **ghutils** is Copyright (c) 2015 Rod Vagg [@rvagg](https://twitter.com/rvagg) and licensed under the MIT licence. All rights not explicitly granted in the MIT license are reserved. See the included LICENSE.md file for more details.

--- a/ghutils.js
+++ b/ghutils.js
@@ -2,6 +2,8 @@ const jsonist = require('jsonist')
     , xtend   = require('xtend')
     , qs      = require('querystring')
 
+    , apiRoot = 'https://api.github.com'
+
 
 function makeOptions (auth, options) {
   return xtend({
@@ -45,7 +47,7 @@ function issuesList (type) {
       options  = {}
     }
 
-    var url = 'https://api.github.com/repos/' + org + '/' + repo + '/' + type
+    var url = apiRoot + '/repos/' + org + '/' + repo + '/' + type
     lister(auth, url, options, callback)
   }
 }
@@ -83,3 +85,4 @@ module.exports.ghget       = ghget
 module.exports.handler     = handler
 module.exports.issuesList  = issuesList
 module.exports.lister      = lister
+module.exports.apiRoot     = apiRoot


### PR DESCRIPTION
Useful for getting rid of hardcoded strings in dependants.
