### PR TITLE
inroduce `afterDate` option for lister

### DIFF
--- a/test.js
+++ b/test.js
@@ -38,6 +38,73 @@ test('that lister follows res.headers.link', function (t) {
 
 })
 
+test('test list multi-page pulls, options.afterDate includes all', function (t) {
+  t.plan(13)
+
+  var auth     = { user: 'authuser', token: 'authtoken' }
+    , org      = 'testorg'
+    , repo     = 'testrepo'
+    , testData = [
+          {
+              response : [ { test1: 'data1', created_at: new Date('2015-12-14T05:58:14.421Z').toISOString() }, { test2: 'data2', created_at: new Date('2015-12-13T05:58:14.421Z').toISOString() } ]
+            , headers  : { link: '<https://api.github.com/foobar?page=2>; rel="next"' }
+          }
+        , {
+              response : [ { test1: 'data3', created_at: new Date('2015-12-12T05:58:14.421Z').toISOString() }, { test2: 'data4', created_at: new Date('2015-12-11T05:58:14.421Z').toISOString() } ]
+            , headers  : { link: '<https://api.github.com/foobar?page=3>; rel="next"' }
+          }
+        , { response: [] }
+      ]
+    , urlBase  = 'https://api.github.com/foobar'
+    , server
+
+  server = util.makeServer(testData)
+    .on('ready', function () {
+      var result = testData[0].response.concat(testData[1].response)
+      ghutils.lister(xtend(auth), urlBase, { afterDate: new Date('2015-12-10T05:58:14.421Z') }, util.verifyData(t, result))
+    })
+    .on('request', util.verifyRequest(t, auth))
+    .on('get', util.verifyUrl(t, [
+        'https://api.github.com/foobar'
+      , 'https://api.github.com/foobar?page=2'
+      , 'https://api.github.com/foobar?page=3'
+    ]))
+    .on('close'  , util.verifyClose(t))
+})
+
+test('test list multi-page pulls, options.afterDate includes all', function (t) {
+  t.plan(10)
+
+  var auth     = { user: 'authuser', token: 'authtoken' }
+    , org      = 'testorg'
+    , repo     = 'testrepo'
+    , testData = [
+          {
+              response : [ { test1: 'data1', created_at: new Date('2015-12-14T05:58:14.421Z').toISOString() }, { test2: 'data2', created_at: new Date('2015-12-13T05:58:14.421Z').toISOString() } ]
+            , headers  : { link: '<https://api.github.com/foobar?page=2>; rel="next"' }
+          }
+        , {
+              response : [ { test1: 'data3', created_at: new Date('2015-12-12T05:58:14.421Z').toISOString() }, { test2: 'data4', created_at: new Date('2015-12-11T05:58:14.421Z').toISOString() } ]
+            , headers  : { link: '<https://api.github.com/foobar?page=3>; rel="next"' }
+          }
+        // also tests that we don't fetch any more beyond this point, i.e. only 2 requests needed
+      ]
+    , urlBase  = 'https://api.github.com/foobar'
+    , server
+
+  server = util.makeServer(testData)
+    .on('ready', function () {
+      var result = testData[0].response.concat([ testData[1].response[0] ])
+      ghutils.lister(xtend(auth), urlBase, { afterDate: new Date('2015-12-11T15:58:14.421Z') }, util.verifyData(t, result))
+    })
+    .on('request', util.verifyRequest(t, auth))
+    .on('get', util.verifyUrl(t, [
+        'https://api.github.com/foobar'
+      , 'https://api.github.com/foobar?page=2'
+    ]))
+    .on('close'  , util.verifyClose(t))
+})
+
 test('valid response with null data calls back with null data', function (t) {
   t.plan(5)
 


### PR DESCRIPTION
for issues and pulls (and anything else containing `created_at`) to limit the returned list to only those after the `Date` provided
