### PR TITLE
bump jsonist to ~2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/rvagg/ghutils.git"
   },
   "dependencies": {
-    "jsonist": "~1.3.0",
+    "jsonist": "~2.1.0",
     "xtend": "~4.0.1"
   },
   "scripts": {


### PR DESCRIPTION
Latest `jsonist` pulls in updated `hyperquest` which removes the weird `TimeoutOverflowWarning` messages below:

```
# test list multi-page pulls, options.afterDate includes all
ok 27 correct url
(node:11547) TimeoutOverflowWarning: 4294967296000 does not fit into a 32-bit signed integer.
Timer duration was truncated to 2147483647.
ok 28 got request
ok 29 got auth header
ok 30 correct url
(node:11547) TimeoutOverflowWarning: 4294967296000 does not fit into a 32-bit signed integer.
Timer duration was truncated to 2147483647.
ok 31 got request
ok 32 got auth header
ok 33 got close
ok 34 no error
ok 35 got data
ok 36 got expected data
# valid response with null data calls back with null data
(node:11547) TimeoutOverflowWarning: 4294967296000 does not fit into a 32-bit signed integer.
Timer duration was truncated to 2147483647.
ok 37 got request
ok 38 got auth header
ok 39 got close
ok 40 no error
ok 41 got expected data
# data.message calls back with error
(node:11547) TimeoutOverflowWarning: 4294967296000 does not fit into a 32-bit signed integer.
Timer duration was truncated to 2147483647.
ok 42 got request
ok 43 got auth header
ok 44 got close
ok 45 should be equivalent
# data.error calls back with error
(node:11547) TimeoutOverflowWarning: 4294967296000 does not fit into a 32-bit signed integer.
Timer duration was truncated to 2147483647.
ok 46 got request
ok 47 got auth header
ok 48 got close
ok 49 should be equivalent

1..49
# tests 49
```