### PR TITLE
delete auth when empty to fix weird github errors

### DIFF
--- a/ghutils.js
+++ b/ghutils.js
@@ -12,6 +12,7 @@ function makeOptions (auth, options) {
   )
   options = xtend({ auth: auth.user + ':' + auth.token }, options)
   options.headers = headers
+  if (!options.auth) delete options.auth
   return options
 }
 


### PR DESCRIPTION
I've started getting Github auth errors on my public repos because it sends an empty auth string.
This PR fixes this by deleting the property if falsy.